### PR TITLE
Use responsive address search box width

### DIFF
--- a/src/app/styles/Header.scss
+++ b/src/app/styles/Header.scss
@@ -40,6 +40,10 @@
   opacity: 0.6;
 }
 
+.searchForm {
+  width: 100%;
+}
+
 .searchInput {
   background-color: #121212;
   border: 1px solid #222222;
@@ -47,7 +51,8 @@
   text-align: center;
   letter-spacing: 1px;
   @extend .text-x-small;
-  min-width: 350px;
+  width: 100%;
+  display: block;
   outline: none;
   @extend .text-medium-grey;
   &:active, &:focus {

--- a/src/app/views/Header.jsx
+++ b/src/app/views/Header.jsx
@@ -9,7 +9,7 @@ import styles from 'Styles/Header.scss'
 import config from 'Config'
 
 let AddressSearchForm = (props) => (
-  <form onSubmit={props.handleSubmit}>
+  <form onSubmit={props.handleSubmit} className={styles.searchForm}>
     <div className='form-group'>
       <InputGroup>
         <Field


### PR DESCRIPTION
This prevents the search box from being cut off on mobile as well as removes the need for a minimum pixel width.